### PR TITLE
CI Fix

### DIFF
--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -13,6 +13,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["cp36", "cp37", "cp38", "cp39", "cp310", "cp311", "cp312", "cp313"]
+        exclude:
+          # Exclude Python 3.6 and 3.7 on macOS (Apple Silicon incompatible)
+          - os: macos-latest
+            python-version: "cp36"
+          - os: macos-latest
+            python-version: "cp37"
+      fail-fast: false
 
     steps:
       - name: Checkout code

--- a/TODO.md
+++ b/TODO.md
@@ -16,10 +16,10 @@
 
 ## Optimizations
 
-- [ ] Support iterative builds in `cibuildwheel` (via separated Python binding project & shared core lib project)
+- [X] Support iterative builds in `cibuildwheel` (via separated Python binding project & shared core lib project)
+- [X] Add source wheel distribution for unsupported Python wheel configurations
+- [X] Split CI/CD pipelines hierarchically
 - [ ] Add missing architectures to CI/CD pipelines (`aarch64` on Linux & Windows, `x86/universal2` on macOS)
-- [ ] Add source wheel distribution for unsupported Python wheel configurations
-- [ ] Split CI/CD pipelines hierarchically
 
 ## Additions
 
@@ -57,7 +57,7 @@
 - [ ] `go` -> `pkg.go`
 - [ ] `java` -> `maven`
 - [ ] `js/ts` -> `npm`
-- [ ] `python` -> `pypl`
+- [X] `python` -> `pypi`
 - [ ] `rust` -> `cargo`
 - [ ] `swift` -> ?
 - [ ] `cli-macos` -> `homebrew`

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -5,6 +5,7 @@ requires = [
     "scikit-build",
     "cmake>=3.17",
     "pybind11[global]>=2.6",
+    "setuptools_scm[toml]>=6.2",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -34,7 +34,7 @@ if platform.system() == "Windows":
 
 setup(
     name="compress-utils",
-    version="0.4.0",
+    use_scm_version=True,
     description="Simple & high-performance compression utilities for Python",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -53,11 +53,12 @@ setup(
         'compress_utils': [
             'README.md',
             'LICENSE',
-            'compress_utils_py*.so',    # For Linux shared libraries
-            'compress_utils_py*.dylib', # For macOS shared libraries
-            'compress_utils_py*.pyd',   # For Windows shared libraries
+            'compress_utils_py*.so',
+            'compress_utils_py*.dylib',
+            'compress_utils_py*.pyd',
         ]
     },
+    setup_requires=["setuptools_scm"],  # Add this
     cmake_args=cmake_args,
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
This PR contains fixes from PR #13:

- Skip Python 3.6-3.7 on macOS (Apple Silicon incompatibility)
- Use `setuptools-scm` to auto-detect Git tag version when building Python wheels