### PR TITLE
Python & C++ CI Fixes

### DIFF
--- a/.github/workflows/build_and_test_c_cpp.yml
+++ b/.github/workflows/build_and_test_c_cpp.yml
@@ -3,6 +3,8 @@ name: Build, Test and Package C/C++
 on:
   push:
     branches: [ "main" ]
+    tags: 
+      - "v*"
 
 jobs:
   build:
@@ -194,3 +196,26 @@ jobs:
       with:
         name: compress-utils-cpp
         path: compress-utils-cpp.zip
+
+    ##### Attach Artifacts to Release (if Tag) #####
+
+    - name: Extract Version from Tag
+      if: github.ref_type == 'tag'
+      run: |
+        VERSION=${GITHUB_REF_NAME#v}  # Strip the 'v' prefix if present
+        echo "Creating archive for version $VERSION"
+        mv compress-utils-c.zip compress-utils-c-${VERSION}.zip
+        mv compress-utils-cpp.zip compress-utils-cpp-${VERSION}.zip
+        echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+    - name: Publish to GitHub Release
+      if: github.ref_type == 'tag'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          compress-utils-c-${{ env.RELEASE_VERSION }}.zip
+          compress-utils-cpp-${{ env.RELEASE_VERSION }}.zip
+        generate_release_notes: false
+        fail_on_unmatched_files: false
+        draft: false
+        tag_name: ${{ github.ref_name }}

--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -40,6 +40,13 @@ jobs:
       - name: Copy Python Bindings Configuration
         run: cp bindings/python/pyproject.toml . && cp bindings/python/setup.py . && cp bindings/python/README.md .
   
+      - name: Set Version from Tag for Wheels
+        if: github.ref_type == 'tag'
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo "Setting exact version $VERSION for tag build"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION" >> $GITHUB_ENV
+
       - name: Build Python Wheels
         env:
           CIBW_BUILD_VERBOSITY: 1
@@ -105,9 +112,8 @@ jobs:
           draft: false
           tag_name: ${{ github.ref_name }}
           
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: wheelhouse/
-          skip-existing: true
+      # - name: Publish to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     packages-dir: wheelhouse/
+      #     skip-existing: true

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -19,6 +19,14 @@ jobs:
         fetch-depth: 0
         clean: true
 
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+
+    - name: Install Python Dependencies
+      run: pip install pybind11 pytest
+
     - name: Configure CMake for All Language Bindings & All Compressors
       run: |
         mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ option(INCLUDE_ZLIB "Include zlib compression algorithm" ON)
 
 # Options to build bindings
 option(BUILD_C_BINDINGS "Build C bindings" ON)
+option(BUILD_PYTHON_BINDINGS "Build Python bindings" ON)
 
 ######### INCLUDE DIRECTORIES #########
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 |:---:|:---:|:---:|
 | C++ | _TBD_ | [C++ API](bindings/cpp/README.md) |
 | C | _TBD_ | [C API](bindings/c/README.md)
-| Python | _TBD_ | [Python API](bindings/python/README.md) |
+| Python | [compress-utils](https://pypi.org/project/compress-utils) | [Python API](bindings/python/README.md) |
 
 ## Usage
 
@@ -92,7 +92,11 @@ You can find language-specific code examples below:
 
 ### Install From Package Manager
 
-_To be added_
+#### Python
+
+```sh
+pip install compress-utils
+```
 
 ### Build From Source
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -78,14 +78,15 @@ else()
     install(FILES ${PYTHON_BINDING_DIR}/README.md ${PYTHON_BINDING_DIR}/pyproject.toml
         DESTINATION ${CMAKE_INSTALL_PREFIX}
     )
-
-    # Move the built Python module to the package directory (from Release/ to the package directory)
-    add_custom_command(TARGET ${PYTHON_MODULE_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        $<TARGET_FILE:${PYTHON_MODULE_NAME}>
-        ${PYTHON_PACKAGE_DIR}
-    )
 endif()
+
+# Move the built Python module to the package directory
+add_custom_command(TARGET ${PYTHON_MODULE_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    $<TARGET_FILE:${PYTHON_MODULE_NAME}>
+    ${PYTHON_PACKAGE_DIR}
+    COMMENT "Copying Python module to package directory"
+)
 
 ######### TESTS #########
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -96,5 +96,15 @@ if(ENABLE_TESTS)
         COMMAND ${Python3_EXECUTABLE} ${PYTHON_BINDING_DIR}/tests/test_compress_utils.py
         WORKING_DIRECTORY ${PYTHON_BINDING_DIR}
     )
-    set_tests_properties(unit_tests_py PROPERTIES ENVIRONMENT "PYTHONPATH=${PYTHON_DIST_DIR}:$ENV{PYTHONPATH}")
+    
+    # Set the PYTHONPATH differently based on platform
+    if(WIN32)
+        # Windows uses semicolons as path separators
+        set_tests_properties(unit_tests_py PROPERTIES
+            ENVIRONMENT "PYTHONPATH=${PYTHON_BINDING_DIR};${CMAKE_BINARY_DIR};${PYTHON_DIST_DIR}")
+    else()
+        # Unix-like systems use colons as path separators
+        set_tests_properties(unit_tests_py PROPERTIES 
+            ENVIRONMENT "PYTHONPATH=${PYTHON_BINDING_DIR}:${PYTHON_DIST_DIR}")
+    endif()
 endif()

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -10,7 +10,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-version_scheme = "post-release"
+version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"
 
 [tool.cibuildwheel]

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -34,7 +34,10 @@ if platform.system() == "Windows":
 
 setup(
     name="compress-utils",
-    use_scm_version=True,
+    use_scm_version={
+        "version_scheme": "guess-next-dev",
+        "local_scheme": "no-local-version",
+    },
     description="Simple & high-performance compression utilities for Python",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Quick fixes for Python versioning & C/C++ release artifact publishing. **This PR temporarily disables PyPI auto-publish on tag, which will need to be reverted after validating the tag CI workflow.**